### PR TITLE
update README file : list all containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 * View all containers:
 
-      kubectl get pods
+      kubectl get pods / kubectl get pods --all-namespaces
 
 * View/Tail logfiles of pod:
 


### PR DESCRIPTION
Hi @mlassnig ! While listing all containers, when I type `kubectl get pods` it is not showing all the containers. Instead this command seems to work `kubectl get pods --all-namespaces`. It might be that the former command line works for other cases but the latter command line should also be included as well by which we can also view the conatiners in all namespaces. Thanks!
