### PR TITLE
Some helpful commands ➟ Added kubectl completion for Zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@
 
 ## Some helpful commands
 
-* Activate kubectl bash completion:
+* Activate kubectl completion:
 
+      # Bash
       source <(kubectl completion bash)
+      # Zsh
+      source <(kubectl completion zsh)
 
 * View all containers:
 


### PR DESCRIPTION
Trying to add the competition for kubectl. The users using the shell Zsh could receive an error and spend time figuring out what is the problem. It is showing in the documentation [kubectl Cheat Sheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/). Adding both versions in the read me for completion should be helpful.