### PR TITLE
Installation Rucio ➟ Improve command line for install Rucio

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ _NOTE: Replace the pod IDs with the ones from your instance, they change every t
 
       helm install server rucio/rucio-server -f server.yaml
       
-      kubectl logs -f server-rucio-server-7fffc4665d-ts67v rucio-server
+      RUCIO_SERVER=$(kubectl get pods | grep ^server-rucio-server- | grep -v auth- | awk '{print $1}')
+      echo "*${RUCIO_SERVER}*"
+      kubectl logs -f ${RUCIO_SERVER} rucio-server
 
 * Prepare a client container for interactive use:
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ _NOTE: Replace the pod IDs with the ones from your instance, they change every t
       helm install server rucio/rucio-server -f server.yaml
       
       RUCIO_SERVER=$(kubectl get pods | grep ^server-rucio-server- | grep -v auth- | awk '{print $1}')
-      echo "*${RUCIO_SERVER}*"
+      echo ${RUCIO_SERVER}
       kubectl logs -f ${RUCIO_SERVER} rucio-server
 
 * Prepare a client container for interactive use:


### PR DESCRIPTION
The documentation could be required less user actions, e.g., delete, copy and paste the server name when install Rucio. The server name “server-rucio-server-77cbff799-bw5tq” could be automatically taken and assigned in the `kubectl` command.

```shell
RUCIO_SERVER=$(kubectl get pods | grep ^server-rucio-server- | grep -v auth- | awk '{print $1}')
echo ${RUCIO_SERVER}
kubectl logs -f ${RUCIO_SERVER} rucio-server
```