### PR TITLE
fix section in rucio client env vars

### DIFF
--- a/client.yaml
+++ b/client.yaml
@@ -22,21 +22,21 @@ spec:
     command: ["/bin/bash"]
     args: ["-c", "mkdir -p /opt/rucio/etc; cp /tmp/usercert.pem /opt/rucio/etc/usercert.pem; cp /tmp/userkey.pem /opt/rucio/etc/userkey.pem; chmod 400 /opt/rucio/etc/userkey.pem; echo ready; while true; do sleep 60; done"]
     env:
-    - name: RUCIO_CFG_RUCIO_HOST
+    - name: RUCIO_CFG_CLIENT_RUCIO_HOST
       value: http://server-rucio-server
-    - name: RUCIO_CFG_AUTH_HOST
+    - name: RUCIO_CFG_CLIENT_AUTH_HOST
       value: http://server-rucio-server
-    - name: RUCIO_CFG_AUTH_TYPE
+    - name: RUCIO_CFG_CLIENT_AUTH_TYPE
       value: userpass
-    - name: RUCIO_CFG_USERNAME
+    - name: RUCIO_CFG_CLIENT_USERNAME
       value: tutorial
-    - name: RUCIO_CFG_PASSWORD
+    - name: RUCIO_CFG_CLIENT_PASSWORD
       value: secret1R
-    - name: RUCIO_CFG_ACCOUNT
+    - name: RUCIO_CFG_CLIENT_ACCOUNT
       value: root
     - name: RUCIO_CFG_CLIENT_CERT
       value: /opt/rucio/etc/usercert.pem
-    - name: RUCIO_CFG_CA_CERT
+    - name: RUCIO_CFG_CLIENT_CA_CERT
       value: /etc/grid-security/certificates/5fca1cb1.0
     - name: RUCIO_CFG_CLIENT_KEY
       value: /opt/rucio/etc/userkey.pem


### PR DESCRIPTION

The rucio client config in `/opt/rucio/etc/rucio.cfg` is generated from env vars  with prefix `RUCIO_CFG_CLIENT` via `/etc/profile.d/rucio_init.sh`

The script `/usr/local/rucio_client/merge_rucio_configs.py` to create that config from env expects a meaningful `section_`  prefix in the variable name after the `rucio_cfg_` prefix is stripped

Also, the script throws an exeption on one word env var like `RUCIO_CFG_PASSWORD`  which don't have any section 
component separated with `_`

https://github.com/rucio/rucio/blob/master/tools/merge_rucio_configs.py#L59

```
Traceback (most recent call last):
  File "/usr/local/rucio_client/merge_rucio_configs.py", line 146, in <module>
    merge_configs(args.source or [], args.destination, use_env=args.use_env)
  File "/usr/local/rucio_client/merge_rucio_configs.py", line 128, in merge_configs
    env_config = fix_multi_word_sections(load_flat_config(env_config))
  File "/usr/local/rucio_client/merge_rucio_configs.py", line 59, in load_flat_config
    section, option = flat_key.split('_', maxsplit=1)
ValueError: not enough values to unpack (expected 2, got 1)
```

This PR corrects the env settings for the rucio client