### PR TITLE
Increased default memory from 2gb->4gb

### DIFF
--- a/automation/01-install-rucio.bash
+++ b/automation/01-install-rucio.bash
@@ -5,9 +5,13 @@ cd "$(dirname "$0")"
 
 # Minikube
 MINIKUBE_ARGS=()
-if [[ -n "${MINIKUBE_MEMORY}" ]]; then
-  MINIKUBE_ARGS+=("--memory=${MINIKUBE_MEMORY}")
+
+# Set default MINIKUBE_MEMORY to 4000mb if it is not specified
+if [[ -z "${MINIKUBE_MEMORY}" ]]; then
+  MINIKUBE_MEMORY="4000mb"
 fi
+MINIKUBE_ARGS+=("--memory=${MINIKUBE_MEMORY}")
+
 if [[ -n "${MINIKUBE_CPU}" ]]; then
   MINIKUBE_ARGS+=("--cpus=${MINIKUBE_CPU}")
 fi


### PR DESCRIPTION
When running the tutorial manually, the user is prompted to instantiate a minikube with 4GB of memory. This should be the same size as when run with the automation scripts, which currently use the minikube default (if the env variable MINIKUBE_MEMORY is not set) of 2GB. 

During testing, I also encountered an error when running with 2GB that did not reproduce when running with 4GB.