### PR TITLE
Update README.md to avoid deprecation notice from kubeclt

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ _NOTE: You can execute this Linux script for easier installation and understandi
 
 * Once the client container is in STATUS:Running, you can jump into it and check if the clients are working:
 
-      kubectl exec -it client /bin/bash
+      kubectl exec -it client -- /bin/bash
 
       rucio whoami
 


### PR DESCRIPTION
The usage of exec command without double dash (`--`) is deprecated.

```
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
```