### PR TITLE
containers: Update K8s manifests to explicitly use psycopg in database URL

### DIFF
--- a/manifests/init-pod.yaml
+++ b/manifests/init-pod.yaml
@@ -12,7 +12,7 @@
        imagePullPolicy: Always
        env:
          - name: RUCIO_CFG_DATABASE_DEFAULT
-           value: postgresql://rucio:secret@postgres-postgresql/rucio
+           value: postgresql+psycopg://rucio:secret@postgres-postgresql/rucio
          - name: RUCIO_CFG_DATABASE_SCHEMA
            value: test
          - name: RUCIO_CFG_BOOTSTRAP_USERPASS_IDENTITY

--- a/manifests/values-daemons.yaml
+++ b/manifests/values-daemons.yaml
@@ -198,7 +198,7 @@ ftsRenewal:
 
 config:
   database:
-    default: postgresql://rucio:secret@postgres-postgresql/rucio
+    default: postgresql+psycopg://rucio:secret@postgres-postgresql/rucio
     schema: test
 
   messaging_hermes:

--- a/manifests/values-server.yaml
+++ b/manifests/values-server.yaml
@@ -6,7 +6,7 @@ image:
 
 config:
   database:
-    default: "postgresql://rucio:secret@postgres-postgresql/rucio"
+    default: "postgresql+psycopg://rucio:secret@postgres-postgresql/rucio"
     schema: "test"
 
 ingress:


### PR DESCRIPTION
fixes #35 