### PR TITLE
Fix: RSE commands in use-rucio.sh

### DIFF
--- a/scripts/use-rucio.sh
+++ b/scripts/use-rucio.sh
@@ -23,45 +23,45 @@ kubectl exec client -it -- /etc/profile.d/rucio_init.sh
 echo "┌─────────────────┐"
 echo "⟾ Create the RSEs │"
 echo "└─────────────────┘"
-kubectl exec client -it -- rucio rse add --rse XRD1
-kubectl exec client -it -- rucio rse add --rse XRD2
-kubectl exec client -it -- rucio rse add --rse XRD3
+kubectl exec client -it -- rucio rse add XRD1
+kubectl exec client -it -- rucio rse add XRD2
+kubectl exec client -it -- rucio rse add XRD3
 
 echo "┌──────────────────────────────────────────────────────┐"
 echo "⟾ Add the protocol definitions for the storage servers │"
 echo "└──────────────────────────────────────────────────────┘"
-kubectl exec client -it -- rucio rse protocol add --host xrd1 --rse XRD1 --scheme root --prefix //rucio --port 1094 --impl rucio.rse.protocols.gfal.Default --domain-json '{"wan": {"read": 1, "write": 1, "delete": 1, "third_party_copy_read": 1, "third_party_copy_write": 1}, "lan": {"read": 1, "write": 1, "delete": 1}}'
-kubectl exec client -it -- rucio rse protocol add --host xrd2 --rse XRD2 --scheme root --prefix //rucio --port 1094 --impl rucio.rse.protocols.gfal.Default --domain-json '{"wan": {"read": 1, "write": 1, "delete": 1, "third_party_copy_read": 1, "third_party_copy_write": 1}, "lan": {"read": 1, "write": 1, "delete": 1}}'
-kubectl exec client -it -- rucio rse protocol add --host xrd3 --rse XRD3 --scheme root --prefix //rucio --port 1094 --impl rucio.rse.protocols.gfal.Default --domain-json '{"wan": {"read": 1, "write": 1, "delete": 1, "third_party_copy_read": 1, "third_party_copy_write": 1}, "lan": {"read": 1, "write": 1, "delete": 1}}'
+kubectl exec client -it -- rucio rse protocol add --host xrd1 XRD1 --scheme root --prefix //rucio --port 1094 --impl rucio.rse.protocols.gfal.Default --domain-json '{"wan": {"read": 1, "write": 1, "delete": 1, "third_party_copy_read": 1, "third_party_copy_write": 1}, "lan": {"read": 1, "write": 1, "delete": 1}}'
+kubectl exec client -it -- rucio rse protocol add --host xrd2 XRD2 --scheme root --prefix //rucio --port 1094 --impl rucio.rse.protocols.gfal.Default --domain-json '{"wan": {"read": 1, "write": 1, "delete": 1, "third_party_copy_read": 1, "third_party_copy_write": 1}, "lan": {"read": 1, "write": 1, "delete": 1}}'
+kubectl exec client -it -- rucio rse protocol add --host xrd3 XRD3 --scheme root --prefix //rucio --port 1094 --impl rucio.rse.protocols.gfal.Default --domain-json '{"wan": {"read": 1, "write": 1, "delete": 1, "third_party_copy_read": 1, "third_party_copy_write": 1}, "lan": {"read": 1, "write": 1, "delete": 1}}'
 
 echo "┌────────────┐"
 echo "⟾ Enable FTS │"
 echo "└────────────┘"
-kubectl exec client -it -- rucio rse attribute add --rse XRD1 --key fts --value https://fts:8446
-kubectl exec client -it -- rucio rse attribute add --rse XRD2 --key fts --value https://fts:8446
-kubectl exec client -it -- rucio rse attribute add --rse XRD3 --key fts --value https://fts:8446
+kubectl exec client -it -- rucio rse attribute add XRD1 --key fts --value https://fts:8446
+kubectl exec client -it -- rucio rse attribute add XRD2 --key fts --value https://fts:8446
+kubectl exec client -it -- rucio rse attribute add XRD3 --key fts --value https://fts:8446
 
 echo "┌──────────────────────────┐"
 echo "⟾ Fake a full mesh network │"
 echo "└──────────────────────────┘"
-kubectl exec client -it -- rucio rse distance add --source XRD1 --destination XRD2 --distance 1
-kubectl exec client -it -- rucio rse distance add --source XRD1 --destination XRD3 --distance 1
-kubectl exec client -it -- rucio rse distance add --source XRD2 --destination XRD1 --distance 1
-kubectl exec client -it -- rucio rse distance add --source XRD2 --destination XRD3 --distance 1
-kubectl exec client -it -- rucio rse distance add --source XRD3 --destination XRD1 --distance 1
-kubectl exec client -it -- rucio rse distance add --source XRD3 --destination XRD2 --distance 1
+kubectl exec client -it -- rucio rse distance add XRD1 XRD2 --distance 1
+kubectl exec client -it -- rucio rse distance add XRD1 XRD3 --distance 1
+kubectl exec client -it -- rucio rse distance add XRD2 XRD1 --distance 1
+kubectl exec client -it -- rucio rse distance add XRD2 XRD3 --distance 1
+kubectl exec client -it -- rucio rse distance add XRD3 XRD1 --distance 1
+kubectl exec client -it -- rucio rse distance add XRD3 XRD2 --distance 1
 
 echo "┌───────────────────────────────────┐"
 echo "⟾ Indefinite storage quota for root │"
 echo "└───────────────────────────────────┘"
-kubectl exec client -it -- rucio account limit add --account root --rses XRD1 --bytes infinity
-kubectl exec client -it -- rucio account limit add --account root --rses XRD2 --bytes infinity
-kubectl exec client -it -- rucio account limit add --account root --rses XRD3 --bytes infinity
+kubectl exec client -it -- rucio account limit add root --rse XRD1 --bytes infinity
+kubectl exec client -it -- rucio account limit add root --rse XRD2 --bytes infinity
+kubectl exec client -it -- rucio account limit add root --rse XRD3 --bytes infinity
 
 echo "┌────────────────────────────────────┐"
 echo "⟾ Create a default scope for testing │"
 echo "└────────────────────────────────────┘"
-kubectl exec client -it -- rucio scope add --account root --scope test
+kubectl exec client -it -- rucio scope add --account root test
 
 echo "┌──────────────────────────────────────┐"
 echo "⟾ Create initial transfer testing data │"
@@ -74,25 +74,25 @@ kubectl exec client -it -- dd if=/dev/urandom of=file4 bs=10M count=1
 echo "┌──────────────────┐"
 echo "⟾ Upload the files │"
 echo "└──────────────────┘"
-kubectl exec client -it -- rucio upload --rse XRD1 --scope test --files file1 file2
-kubectl exec client -it -- rucio upload --rse XRD2 --scope test --files file3 file4
+kubectl exec client -it -- rucio upload --rse XRD1 --scope test file1 file2
+kubectl exec client -it -- rucio upload --rse XRD2 --scope test file3 file4
 
 echo "┌──────────────────────────────────────┐"
 echo "⟾ Create a few datasets and containers │"
 echo "└──────────────────────────────────────┘"
-kubectl exec client -it -- rucio did add --type dataset --did test:dataset1
-kubectl exec client -it -- rucio did content add --to test:dataset1 --did test:file1 test:file2
-kubectl exec client -it -- rucio did add --type dataset --did test:dataset2
-kubectl exec client -it -- rucio did content add --to test:dataset2 --did test:file3 test:file4
-kubectl exec client -it -- rucio did add --type container --did test:container
-kubectl exec client -it -- rucio did content add --to test:container --did test:dataset1 test:dataset2
-kubectl exec client -it -- rucio did add --type dataset --did test:dataset3
-kubectl exec client -it -- rucio did content add --to test:dataset3 --did test:file4
+kubectl exec client -it -- rucio did add --type dataset test:dataset1
+kubectl exec client -it -- rucio did content add -to test:dataset1 test:file1 test:file2
+kubectl exec client -it -- rucio did add --type dataset test:dataset2
+kubectl exec client -it -- rucio did content add -to test:dataset2 test:file3 test:file4
+kubectl exec client -it -- rucio did add --type container test:container
+kubectl exec client -it -- rucio did content add -to test:container test:dataset1 test:dataset2
+kubectl exec client -it -- rucio did add --type dataset test:dataset3
+kubectl exec client -it -- rucio did content add -to test:dataset3 test:file4
 
 echo "┌─────────────────────────────────────────────┐"
 echo "⟾ Create a rule and remember returned rule ID │"
 echo "└─────────────────────────────────────────────┘"
-kubectl exec client -it -- rucio rule add --did test:container --rses XRD3 --copies 1
+kubectl exec client -it -- rucio rule add test:container --rses XRD3 --copies 1
 
 echo "┌────────────────────────────────────────────────────┐"
 echo "⟾ Query the status of the rule until it is completed │"
@@ -101,7 +101,7 @@ echo "⤑ It will wait for 90 seconds."
 sleep 90
 RULE_ID=$(kubectl exec client -it -- rucio rule list --did test:container | tail -n 1 | awk '{print $1}')
 echo "RULE_ID: ${RULE_ID}"
-kubectl exec client -it -- rucio rule show --rule-id "${RULE_ID}"
+# kubectl exec client -it -- rucio rule show "${RULE_ID}"
 
 echo""
 echo""

--- a/scripts/use-rucio.sh
+++ b/scripts/use-rucio.sh
@@ -101,7 +101,7 @@ echo "⤑ It will wait for 90 seconds."
 sleep 90
 RULE_ID=$(kubectl exec client -it -- rucio rule list --did test:container | tail -n 1 | awk '{print $1}')
 echo "RULE_ID: ${RULE_ID}"
-# kubectl exec client -it -- rucio rule show "${RULE_ID}"
+kubectl exec client -it -- rucio rule show "${RULE_ID}"
 
 echo""
 echo""


### PR DESCRIPTION
Addresses #44 

Logs after running modified script:

```
./scripts/use-rucio.sh 
┌─────────────────────────────────────────────────────────────────┐
⟾ kubectl: Rucio - Start client container pod for interactive use │
└─────────────────────────────────────────────────────────────────┘
pod/client created
pod/client condition met
┌─────────────────────────────────┐
⟾ kubectl: Check client container │
└─────────────────────────────────┘
File rucio.cfg not found. It will generate one.
INFO:root:Merged 16 configuration values from /opt/user/rucio.default.cfg
INFO:root:Merged 10 configuration values from ENV
INFO:root:Writing /opt/rucio/etc/rucio.cfg
Enable shell completion on the rucio commands
suspended_at : None
account_type : SERVICE
status     : ACTIVE
created_at : 2025-08-15T12:07:32
email      : None
account    : root
deleted_at : None
updated_at : 2025-08-15T12:07:32
┌────────────────┐
⟾ Run Rucio init │
└────────────────┘
Enable shell completion on the rucio commands
┌─────────────────┐
⟾ Create the RSEs │
└─────────────────┘
Added new deterministic RSE: XRD1
Added new deterministic RSE: XRD2
Added new deterministic RSE: XRD3
┌──────────────────────────────────────────────────────┐
⟾ Add the protocol definitions for the storage servers │
└──────────────────────────────────────────────────────┘
┌────────────┐
⟾ Enable FTS │
└────────────┘
Added new RSE attribute for XRD1: fts-https://fts:8446 
Added new RSE attribute for XRD2: fts-https://fts:8446 
Added new RSE attribute for XRD3: fts-https://fts:8446 
┌──────────────────────────┐
⟾ Fake a full mesh network │
└──────────────────────────┘
Set distance from XRD1 to XRD2 to 1
Set distance from XRD1 to XRD3 to 1
Set distance from XRD2 to XRD1 to 1
Set distance from XRD2 to XRD3 to 1
Set distance from XRD3 to XRD1 to 1
Set distance from XRD3 to XRD2 to 1
┌───────────────────────────────────┐
⟾ Indefinite storage quota for root │
└───────────────────────────────────┘
Set account limit for account root on RSE XRD1: -1.000 B
Set account limit for account root on RSE XRD2: -1.000 B
Set account limit for account root on RSE XRD3: -1.000 B
┌────────────────────────────────────┐
⟾ Create a default scope for testing │
└────────────────────────────────────┘
Added new scope to root: test
┌──────────────────────────────────────┐
⟾ Create initial transfer testing data │
└──────────────────────────────────────┘
1+0 records in
1+0 records out
10485760 bytes (10 MB, 10 MiB) copied, 0.0593092 s, 177 MB/s
1+0 records in
1+0 records out
10485760 bytes (10 MB, 10 MiB) copied, 0.0778584 s, 135 MB/s
1+0 records in
1+0 records out
10485760 bytes (10 MB, 10 MiB) copied, 0.0779633 s, 134 MB/s
1+0 records in
1+0 records out
10485760 bytes (10 MB, 10 MiB) copied, 0.0702079 s, 149 MB/s
┌──────────────────┐
⟾ Upload the files │
└──────────────────┘
2025-08-15 12:09:05,723 INFO    Preparing upload for file file1
2025-08-15 12:09:05,959 INFO    Successfully added replica in Rucio catalogue at XRD1
2025-08-15 12:09:06,084 INFO    Successfully added replication rule at XRD1
250815 12:09:06 206 cryptossl_X509CreateProxy: Your identity: /CN=Rucio User
2025-08-15 12:09:06,473 INFO    Trying upload with root to XRD1
2025-08-15 12:09:06,805 INFO    Successful upload of temporary file. root://xrd1:1094//rucio/test/80/25/file1.rucio.upload
2025-08-15 12:09:06,840 INFO    Successfully uploaded file file1
2025-08-15 12:09:06,905 INFO    Preparing upload for file file2
2025-08-15 12:09:06,986 INFO    Successfully added replica in Rucio catalogue at XRD1
2025-08-15 12:09:07,034 INFO    Successfully added replication rule at XRD1
2025-08-15 12:09:07,037 INFO    Trying upload with root to XRD1
2025-08-15 12:09:07,102 INFO    Successful upload of temporary file. root://xrd1:1094//rucio/test/f3/14/file2.rucio.upload
2025-08-15 12:09:07,127 INFO    Successfully uploaded file file2
2025-08-15 12:09:07,955 INFO    Preparing upload for file file3
2025-08-15 12:09:08,049 INFO    Successfully added replica in Rucio catalogue at XRD2
2025-08-15 12:09:08,123 INFO    Successfully added replication rule at XRD2
TLS: Unable to create TLS context; invalid private key.
TLS: 40A61191997F0000:error:05800074:x509 certificate routines:ossl_x509_check_private_key:key values mismatch:crypto/x509/x509_cmp.c:416:

2025-08-15 12:09:08,372 INFO    Trying upload with root to XRD2
2025-08-15 12:09:08,557 INFO    Successful upload of temporary file. root://xrd2:1094//rucio/test/a9/23/file3.rucio.upload
2025-08-15 12:09:08,586 INFO    Successfully uploaded file file3
2025-08-15 12:09:08,657 INFO    Preparing upload for file file4
2025-08-15 12:09:08,728 INFO    Successfully added replica in Rucio catalogue at XRD2
2025-08-15 12:09:08,807 INFO    Successfully added replication rule at XRD2
2025-08-15 12:09:08,810 INFO    Trying upload with root to XRD2
2025-08-15 12:09:08,867 INFO    Successful upload of temporary file. root://xrd2:1094//rucio/test/2b/c2/file4.rucio.upload
2025-08-15 12:09:08,895 INFO    Successfully uploaded file file4
┌──────────────────────────────────────┐
⟾ Create a few datasets and containers │
└──────────────────────────────────────┘
Added test:dataset1
DIDs successfully attached to test:dataset1
Added test:dataset2
DIDs successfully attached to test:dataset2
Added test:container
DIDs successfully attached to test:container
Added test:dataset3
DIDs successfully attached to test:dataset3
┌─────────────────────────────────────────────┐
⟾ Create a rule and remember returned rule ID │
└─────────────────────────────────────────────┘
f8152ed5cbe941c3a9492521bea95574
┌────────────────────────────────────────────────────┐
⟾ Query the status of the rule until it is completed │
└────────────────────────────────────────────────────┘
⤑ It will wait for 90 seconds.

```